### PR TITLE
tweak gulpfile to correctly run tasks after twig/php gulp watch notic…

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -282,7 +282,7 @@ const serve = (done) => {
     logLevel: localConfig.bs.logLevel || 'info',
   });
 
-  gulp.watch(config.theme + '/**/*.{twig,php}', scripts, copy, reload);
+  gulp.watch(config.theme + '/**/*.{twig,php}', gulp.series(scripts, copy, reload));
   gulp.watch(config.assets + '/scss/**/*.scss', styles);
   gulp.watch(config.assets + '/js/**/*.js', gulp.series(scripts, copy, reload));
   gulp.watch(config.assets + '/{img,fonts}/**', gulp.series(copy, reload));

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -282,7 +282,7 @@ const serve = (done) => {
     logLevel: localConfig.bs.logLevel || 'info',
   });
 
-  gulp.watch(config.theme + '/**/*.{twig,php}', gulp.series(scripts, copy, reload));
+  gulp.watch(config.theme + '/**/*.{twig,php}', gulp.series(reload));
   gulp.watch(config.assets + '/scss/**/*.scss', styles);
   gulp.watch(config.assets + '/js/**/*.js', gulp.series(scripts, copy, reload));
   gulp.watch(config.assets + '/{img,fonts}/**', gulp.series(copy, reload));


### PR DESCRIPTION
…es a file update

This Pull request fixes the now browser refresh issue, #177. When there are multiple tasks, [gulp watch expects them in an array or gulp.series](https://gulpjs.com/docs/en/getting-started/watching-files/). Tested locally on a recent project