### PR TITLE
Making docker orb friendly, customize locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,13 +57,15 @@ wp-content/plugins/hello.php
 wp-admin/
 wp-includes/
 
-# ignore everything in the "plugins" directory,
-# except the plugins you specify
+# ignore everything in the "plugins" directory, except the plugins you specify
+# this is for a site that uses composer to manage plugins and not track them in source
 # wp-content/plugins/*
-#!wp-content/plugins/stop-emails/# ignore everything in the "mu-plugins" directory,
+#!wp-content/plugins/stop-emails/
+
+# ignore everything in the "mu-plugins" directory,
 # except the mu-plugins you specify
-wp-content/mu-plugins/*
-!wp-content/mu-plugins/local-plugins.php
+!wp-content/mu-plugins/*
+wp-content/mu-plugins/local-plugins.php
 
 # ignore specific theme assets
 wp-content/themes/timber/assets/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,11 @@ composer.lock
 
 # development-environment
 tmp/
+wp-content/mu-plugins/local-plugins.php
 docker-compose.local.yml
+!_init/docker-compose.local.yml
 wp-content/themes/timber/dev/
 wp-config-local.php
-/wp-content/mu-plugins/local-plugins.php
 _data/
 /gulpconfig.json
 info.php
@@ -59,7 +60,19 @@ wp-includes/
 # ignore everything in the "plugins" directory,
 # except the plugins you specify
 # wp-content/plugins/*
-#!wp-content/plugins/stop-emails/
+#!wp-content/plugins/stop-emails/# ignore everything in the "mu-plugins" directory,
+# except the mu-plugins you specify
+wp-content/mu-plugins/*
+!wp-content/mu-plugins/local-plugins.php
+
+# ignore specific theme assets
+wp-content/themes/timber/assets/vendor
+wp-content/themes/timber/static
+wp-content/themes/timber/dist
+
+# ignore specific files in the root directory
+.gitattributes
+.gitignore
 
 # ignore certain plugins
 wp-content/plugins/hello.php

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ composer.lock
 
 # development-environment
 tmp/
-wp-content/mu-plugins/local-plugins.php
 docker-compose.local.yml
 !_init/docker-compose.local.yml
 wp-content/themes/timber/dev/
@@ -64,7 +63,7 @@ wp-includes/
 
 # ignore everything in the "mu-plugins" directory,
 # except the mu-plugins you specify
-!wp-content/mu-plugins/*
+# !wp-content/mu-plugins/*
 wp-content/mu-plugins/local-plugins.php
 
 # ignore specific theme assets

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ composer.lock
 
 # development-environment
 tmp/
+docker-compose.local.yml
 wp-content/themes/timber/dev/
 wp-config-local.php
 /wp-content/mu-plugins/local-plugins.php

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,7 @@
     {
       "label": "Wordpress Docker Recreate",
       "type": "shell",
-      "command": "docker-compose up --build --force-recreate --no-deps"
+      "command": "docker-compose -f docker-compose.yml -f docker-compose.local.yml up --build --force-recreate --no-deps"
     },
     {
       "label": "Wordpress Composer Install",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,7 @@
     {
       "label": "Wordpress Dev",
       "type": "shell",
-      "command": "docker-compose up --build"
+      "command": "docker-compose -f docker-compose.yml -f docker-compose.local.yml up --build"
     },
     {
       "label": "Gulp Dev",

--- a/_build/.deploy_exclude.txt
+++ b/_build/.deploy_exclude.txt
@@ -16,6 +16,7 @@ _init/
 composer.json
 composer.lock
 docker-compose.yml
+docker-compose.local.yml
 gulpfile.mjs
 package.json
 README.md

--- a/_init/docker-compose.local.yml
+++ b/_init/docker-compose.local.yml
@@ -1,0 +1,22 @@
+# copy this to the root of your project if you wan to customize the docker-compose.yml file defaults
+# common usage are to change the ports or to add environment variables
+# make sure when you run docker, you incorporate -- see .vscode/tasks.json for an example
+
+# version: '3.3'
+
+# services:
+#   db:
+#     ports:
+#       - '3307:3306'
+
+#   wordpress:
+#     ports:
+#       - '8000:80'
+#     environment:
+#       WORDPRESS_CONFIG_EXTRA: |
+#         define('WP_ENV', 'development');
+#         define('WP_LOCAL_DEV', true);
+#         define('WP_THEME', 'timber');
+#         define('WP_DEBUG_LOG', true );
+#         define('WP_DEBUG_DISPLAY', false);
+#         @ini_set('display_errors', 0);

--- a/_init/gulpconfig.json
+++ b/_init/gulpconfig.json
@@ -5,7 +5,7 @@
     "debug": false
   },
   "bs": {
-    "proxy": "localhost:8000",
+    "proxy": "http://wordpress.bubstimber.orb.local",
     "logLevel": "info",
     "tunnel": "",
     "open": false

--- a/_init/init.sh
+++ b/_init/init.sh
@@ -16,6 +16,7 @@ rm -rf wp-content/plugins/hello.php
 # init files if they don't exist
 mkdir -p wp-content/mu-plugins
 cp -n _init/local-plugins.php wp-content/mu-plugins/local-plugins.php 2>/dev/null || :
+cp -n _init/docker-compose.local.yml docker-compose.local.yml 2>/dev/null || :
 cp -n _init/gulpconfig.json gulpconfig.json 2>/dev/null || :
 cp -n _init/local.sql _data/local.sql 2>/dev/null || :
 cp -n _init/local-plugins.php wp-content/mu-plugins/local-plugins.php 2>/dev/null || :

--- a/_init/local.sql
+++ b/_init/local.sql
@@ -1,6 +1,11 @@
 ## Update main site
-UPDATE `wp_options` SET `option_value` = 'http://localhost:8000' WHERE `option_name` = 'siteurl';
-UPDATE `wp_options` SET `option_value` = 'http://localhost:8000' WHERE `option_name` = 'home';
+UPDATE `wp_options` SET `option_value` = 'http://wordpress.saltlaw.orb.local' WHERE `option_name` = 'siteurl';
+UPDATE `wp_options` SET `option_value` = 'http://wordpress.saltlaw.orb.local' WHERE `option_name` = 'home';
+
+## Alternate if using localhost instead of orb
+-- UPDATE `wp_options` SET `option_value` = 'http://localhost:8000' WHERE `option_name` = 'siteurl';
+-- UPDATE `wp_options` SET `option_value` = 'http://localhost:8000' WHERE `option_name` = 'home';
+
 
 ## Update multisites
 -- UPDATE `wp_site` SET `domain` = 'localhost:8000' WHERE `id` = '1';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.3'
 services:
   db:
     image: mariadb
-    ports:
-      - '3307:3306'
     volumes:
       - db_data:/var/lib/mysql
     restart: 'no'
@@ -18,8 +16,6 @@ services:
     depends_on:
       - db
     image: wordpress:6.3
-    ports:
-      - '8000:80'
     volumes:
       - ./.htaccess:/var/www/html/.htaccess
       - ./wp-content:/var/www/html/wp-content

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -41,7 +41,7 @@ try {
       debug: false,
     },
     bs: {
-      proxy: "http://localhost:8000",
+      proxy: "http://wordpress.bubstimber.orb.local",
       logLevel: "info",
       tunnel: "",
       open: true,


### PR DESCRIPTION
refs https://github.com/patronage/bubs-next/issues/291

With this appraoch, we have defaults that will support orb based docker, but make it trivial to override with specific ports if you'd like.

Another upshot is your `docker-compose.local.yml` (which is gitignored) can overload WP env variables passed via docker config. So you can test production gulp build settings for example without accidentally committing.

I tried keeping the defaults with ports, then ovveriding with local, but it wasn't straightforward to unset the original ports.

with 